### PR TITLE
Add support for splitted output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.0 - Unreleased
 
+### Added
+
+- Add `config.typesPath` to generate the factories in a different file than the types
+- Add `config.importTypesNamespace` to customize the name of the import namespace
+
 ### Changed
 
 - Upgrade dependencies and drop support for Node 10 in the process

--- a/examples/near-operation-file-preset/codegen.yml
+++ b/examples/near-operation-file-preset/codegen.yml
@@ -1,0 +1,15 @@
+overwrite: true
+schema: ./examples/near-operation-file-preset/schema.graphql
+documents: ./examples/near-operation-file-preset/**/*.graphql
+generates:
+  ./examples/near-operation-file-preset/generated/types.ts:
+    plugins:
+      - typescript
+  ./examples/near-operation-file-preset/:
+    preset: near-operation-file
+    presetConfig:
+      extension: .generated.ts
+      baseTypesPath: ./generated/types.ts
+    plugins:
+      - typescript-operations
+      - ./build/index.js

--- a/examples/near-operation-file-preset/generated/types.ts
+++ b/examples/near-operation-file-preset/generated/types.ts
@@ -1,0 +1,49 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  createUser: User;
+  updateUser: User;
+};
+
+
+export type MutationCreateUserArgs = {
+  name: Scalars['String'];
+  role: UserRole;
+};
+
+
+export type MutationUpdateUserArgs = {
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  role: UserRole;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  users: Array<User>;
+};
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  role: UserRole;
+};
+
+export enum UserRole {
+  Admin = 'ADMIN',
+  User = 'USER'
+}

--- a/examples/near-operation-file-preset/operations/CreateUser.generated.ts
+++ b/examples/near-operation-file-preset/operations/CreateUser.generated.ts
@@ -1,0 +1,19 @@
+import * as Types from '../generated/types';
+
+export type CreateUserMutationVariables = Types.Exact<{
+  name: Types.Scalars['String'];
+  role: Types.UserRole;
+}>;
+
+
+export type CreateUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'User', id: string, name: string, role: Types.UserRole } };
+
+export function createUserMock(props: Partial<Types.User>): Types.User {
+  return {
+    __typename: "User",
+    id: "",
+    name: "",
+    role: Types.UserRole.Admin,
+    ...props,
+  };
+}

--- a/examples/near-operation-file-preset/operations/CreateUser.graphql
+++ b/examples/near-operation-file-preset/operations/CreateUser.graphql
@@ -1,0 +1,7 @@
+mutation CreateUser($name: String!, $role: UserRole!) {
+  createUser(name: $name, role: $role) {
+    id
+    name
+    role
+  }
+}

--- a/examples/near-operation-file-preset/operations/UpdateUser.generated.ts
+++ b/examples/near-operation-file-preset/operations/UpdateUser.generated.ts
@@ -1,0 +1,20 @@
+import * as Types from '../generated/types';
+
+export type UpdateUserOperationMutationVariables = Types.Exact<{
+  id: Types.Scalars['ID'];
+  name: Types.Scalars['String'];
+  role: Types.UserRole;
+}>;
+
+
+export type UpdateUserOperationMutation = { __typename?: 'Mutation', updateUser: { __typename?: 'User', id: string, name: string } };
+
+export function createUserMock(props: Partial<Types.User>): Types.User {
+  return {
+    __typename: "User",
+    id: "",
+    name: "",
+    role: Types.UserRole.Admin,
+    ...props,
+  };
+}

--- a/examples/near-operation-file-preset/operations/UpdateUser.graphql
+++ b/examples/near-operation-file-preset/operations/UpdateUser.graphql
@@ -1,0 +1,6 @@
+mutation UpdateUserOperation($id: ID!, $name: String!, $role: UserRole!) {
+  updateUser(id: $id, name: $name, role: $role) {
+    id
+    name
+  }
+}

--- a/examples/near-operation-file-preset/schema.graphql
+++ b/examples/near-operation-file-preset/schema.graphql
@@ -1,0 +1,19 @@
+enum UserRole {
+  ADMIN
+  USER
+}
+
+type User {
+  id: ID!
+  name: String!
+  role: UserRole!
+}
+
+type Query {
+  users: [User!]!
+}
+
+type Mutation {
+  createUser(name: String!, role: UserRole!): User!
+  updateUser(id: ID!, name: String!, role: UserRole!): User!
+}

--- a/examples/splitted-output/codegen.yml
+++ b/examples/splitted-output/codegen.yml
@@ -1,0 +1,12 @@
+overwrite: true
+schema: ./examples/splitted-output/schema.graphql
+generates:
+  ./examples/splitted-output/generated/factories.ts:
+    plugins:
+      - ./build/index.js
+    config:
+      typesPath: ./types
+      importTypesNamespace: SharedTypes
+  ./examples/splitted-output/generated/types.ts:
+    plugins:
+      - typescript

--- a/examples/splitted-output/generated/factories.ts
+++ b/examples/splitted-output/generated/factories.ts
@@ -1,0 +1,45 @@
+import * as SharedTypes from './types';
+
+export function createDogMock(props: Partial<SharedTypes.Dog>): SharedTypes.Dog {
+  return {
+    __typename: "Dog",
+    id: "",
+    name: "",
+    ...props,
+  };
+}
+
+export function createDroidMock(props: Partial<SharedTypes.Droid>): SharedTypes.Droid {
+  return {
+    __typename: "Droid",
+    codeName: "",
+    id: "",
+    ...props,
+  };
+}
+
+export function createHumanoidConnectionMock(props: Partial<SharedTypes.HumanoidConnection>): SharedTypes.HumanoidConnection {
+  return {
+    __typename: "HumanoidConnection",
+    edges: [],
+    ...props,
+  };
+}
+
+export function createHumanoidNodeMock(props: Partial<SharedTypes.HumanoidNode>): SharedTypes.HumanoidNode {
+  return {
+    __typename: "HumanoidNode",
+    node: createDroidMock({}),
+    ...props,
+  };
+}
+
+export function createUserMock(props: Partial<SharedTypes.User>): SharedTypes.User {
+  return {
+    __typename: "User",
+    companion: createDogMock({}),
+    id: "",
+    role: SharedTypes.UserRole.Admin,
+    ...props,
+  };
+}

--- a/examples/splitted-output/generated/types.ts
+++ b/examples/splitted-output/generated/types.ts
@@ -1,0 +1,59 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+};
+
+export type Companion = Dog | Droid;
+
+export type Dog = {
+  __typename?: 'Dog';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+};
+
+export type Droid = Humanoid & {
+  __typename?: 'Droid';
+  codeName: Scalars['String'];
+  id: Scalars['ID'];
+};
+
+export type Humanoid = {
+  id: Scalars['ID'];
+};
+
+export type HumanoidConnection = {
+  __typename?: 'HumanoidConnection';
+  edges: Array<Maybe<HumanoidNode>>;
+};
+
+export type HumanoidNode = {
+  __typename?: 'HumanoidNode';
+  node: Humanoid;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  searchHumanoids?: Maybe<HumanoidConnection>;
+  users: Array<User>;
+};
+
+export type User = Humanoid & {
+  __typename?: 'User';
+  companion: Companion;
+  id: Scalars['ID'];
+  role: UserRole;
+};
+
+export enum UserRole {
+  Admin = 'ADMIN',
+  SuperAdmin = 'SUPER_ADMIN'
+}

--- a/examples/splitted-output/schema.graphql
+++ b/examples/splitted-output/schema.graphql
@@ -1,0 +1,39 @@
+enum UserRole {
+  SUPER_ADMIN
+  ADMIN
+}
+
+interface Humanoid {
+  id: ID!
+}
+
+type User implements Humanoid {
+  id: ID!
+  role: UserRole!
+  companion: Companion!
+}
+
+type Droid implements Humanoid {
+  id: ID!
+  codeName: String!
+}
+
+type Dog {
+  id: ID!
+  name: String!
+}
+
+union Companion = Droid | Dog
+
+type Query {
+  users: [User!]!
+  searchHumanoids: HumanoidConnection
+}
+
+type HumanoidConnection {
+  edges: [HumanoidNode]!
+}
+
+type HumanoidNode {
+  node: Humanoid!
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -644,6 +644,16 @@
         "tslib": "^2"
       }
     },
+    "@graphql-codegen/add": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-3.1.1.tgz",
+      "integrity": "sha512-XkVwcqosa0CVBlL1HaQT0gp+EUfhuQE3LzrEpzMQLwchxaj/NPVYtOJL6MUHaYDsHzLqxWrufjfbeB3y2NQgRw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.3.2",
+        "tslib": "~2.3.0"
+      }
+    },
     "@graphql-codegen/cli": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-2.6.2.tgz",
@@ -788,6 +798,20 @@
         "tslib": "~2.3.0"
       }
     },
+    "@graphql-codegen/near-operation-file-preset": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/near-operation-file-preset/-/near-operation-file-preset-2.2.6.tgz",
+      "integrity": "sha512-c72G08DDqTYGG1TWRbWfOxX3csjjuZciPOpyM0352tBF6otKIypnxFj+inEnenjWeIY5PrGOIU2J5Uyz8IGaAw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/add": "^3.1.1",
+        "@graphql-codegen/plugin-helpers": "^2.4.0",
+        "@graphql-codegen/visitor-plugin-common": "2.7.1",
+        "@graphql-tools/utils": "^8.5.2",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.3.0"
+      }
+    },
     "@graphql-codegen/plugin-helpers": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.4.1.tgz",
@@ -820,6 +844,19 @@
       "requires": {
         "@graphql-codegen/plugin-helpers": "^2.4.0",
         "@graphql-codegen/schema-ast": "^2.4.1",
+        "@graphql-codegen/visitor-plugin-common": "2.7.1",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.3.0"
+      }
+    },
+    "@graphql-codegen/typescript-operations": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-2.3.2.tgz",
+      "integrity": "sha512-VLB466ffcT25imuq85ANVqVotVaT4T1gJ6FLJsiJkn5U/iMMZa8CvP+l9oSqDlaBotv38LIZX6pdWGNGAn7kDA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^2.4.0",
+        "@graphql-codegen/typescript": "^2.4.5",
         "@graphql-codegen/visitor-plugin-common": "2.7.1",
         "auto-bind": "~4.0.0",
         "tslib": "~2.3.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.6.2",
+    "@graphql-codegen/near-operation-file-preset": "^2.2.6",
     "@graphql-codegen/typescript": "2.4.5",
+    "@graphql-codegen/typescript-operations": "^2.3.2",
     "@types/jest": "^27.4.0",
     "graphql": "^16.3.0",
     "jest": "^27.5.1",
@@ -43,7 +45,7 @@
     "build": "tsc",
     "test": "jest",
     "prebuild:examples": "npm run build",
-    "build:examples": "graphql-codegen --config ./examples/basic/codegen.yml",
+    "build:examples": "bash ./scripts/build-examples.sh",
     "postbuild:examples": "tsc --project ./examples/tsconfig.json",
     "prepare": "npm run build"
   }

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,8 @@ generates:
 
 - [`config.factoryName`](#configfactoryName)
 - [`config.scalarDefaults`](#configscalarDefaults)
+- [`config.typesPath`](#typesPath)
+- [`config.importTypesNamespace`](#importTypesNamespace)
 
 ### `config.factoryName`
 
@@ -114,6 +116,49 @@ generates:
     config:
       scalarDefaults:
         Boolean: true
+```
+
+### `config.typesPath`
+
+By default the generated factories assume that the types are in the same file. If you want to have separate files, for example `types.ts` with the types and `factories.ts` for the factories, you need to provide the path to `config.typesPath`.
+
+```yml
+overwrite: true
+schema: ./schema.graphql
+generates:
+  ./types.ts:
+    plugins:
+      - typescript
+  ./factories.ts
+    plugins:
+      - graphql-codegen-factories
+    config:
+      typesPath: ./types
+```
+
+### `config.importTypesNamespace`
+
+With `config.typesPath`, an import statement is preprended to the factories file:
+
+```typescript
+import * as Types from "./types";
+```
+
+By default types are imported as `Types` but you can customize it by providing another name to `config.importTypesNamespace`.
+
+```yml
+overwrite: true
+schema: ./schema.graphql
+generates:
+  ./types.ts:
+    plugins:
+      - typescript
+  ./factories.ts
+    plugins:
+      - graphql-codegen-factories
+    config:
+      typesPath: ./types
+      importTypesNamespace: SharedTypes
 ```
 
 ## Changelog

--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+for d in examples/*/ ; do
+    npx graphql-codegen --config "./$d/codegen.yml"
+done

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,5 +20,12 @@ export const plugin: PluginFunction<
     .definitions.filter(Boolean)
     .join("\n");
 
-  return { content };
+  return {
+    prepend: visitor.config.typesPath
+      ? [
+          `import * as ${visitor.config.namespacedImportName} from '${visitor.config.typesPath}';\n`,
+        ]
+      : [],
+    content,
+  };
 };


### PR DESCRIPTION
This PR adds support for splitted output. It is required in order to add support for [`near-operation-file-preset`](https://www.graphql-code-generator.com/plugins/near-operation-file-preset), as suggested in #17.

Closes #19 