### PR TITLE
Generate factories for unions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Add `__typename` to operations' root
+- Add support for unions
 
 ## 1.0.0-beta.3 - 2022-04-11
 

--- a/packages/graphql-codegen-factories/src/FactoriesBaseVisitor.ts
+++ b/packages/graphql-codegen-factories/src/FactoriesBaseVisitor.ts
@@ -1,10 +1,6 @@
 import {
   GraphQLSchema,
-  ObjectTypeDefinitionNode,
-  FieldDefinitionNode,
   GraphQLEnumType,
-  InputObjectTypeDefinitionNode,
-  InputValueDefinitionNode,
   isEnumType,
   isUnionType,
   GraphQLUnionType,
@@ -15,9 +11,7 @@ import {
 } from "graphql";
 import {
   BaseVisitor,
-  DeclarationBlock,
   getConfigValue,
-  indent,
   ParsedTypesConfig,
   RawTypesConfig,
 } from "@graphql-codegen/visitor-plugin-common";
@@ -53,11 +47,6 @@ export interface FactoriesBaseVisitorParsedConfig extends ParsedTypesConfig {
   namespacedImportName: string | null;
   typesPath?: string;
   importTypesNamespace?: string;
-}
-
-export interface TypeValue {
-  defaultValue: string;
-  isNullable: boolean;
 }
 
 export class FactoriesBaseVisitor extends BaseVisitor<
@@ -200,42 +189,5 @@ export class FactoriesBaseVisitor extends BaseVisitor<
     }
 
     return name;
-  }
-
-  protected convertField(
-    node: FieldDefinitionNode | InputValueDefinitionNode
-  ): string {
-    const { defaultValue, isNullable } = node.type as unknown as TypeValue;
-    return indent(
-      indent(`${node.name.value}: ${isNullable ? "null" : defaultValue},`)
-    );
-  }
-
-  protected convertObjectType(
-    node: ObjectTypeDefinitionNode | InputObjectTypeDefinitionNode
-  ): string {
-    return new DeclarationBlock(this._declarationBlockConfig)
-      .export()
-      .asKind("function")
-      .withName(
-        `${this.convertFactoryName(
-          node
-        )}(props: Partial<${this.convertNameWithNamespace(
-          node
-        )}>): ${this.convertNameWithNamespace(node)}`
-      )
-      .withBlock(
-        [
-          indent("return {"),
-          node.kind === "ObjectTypeDefinition"
-            ? indent(indent(`__typename: "${node.name.value}",`))
-            : null,
-          ...(node.fields ?? []),
-          indent(indent("...props,")),
-          indent("};"),
-        ]
-          .filter(Boolean)
-          .join("\n")
-      ).string;
   }
 }

--- a/packages/graphql-codegen-factories/src/schema/FactoriesSchemaVisitor.ts
+++ b/packages/graphql-codegen-factories/src/schema/FactoriesSchemaVisitor.ts
@@ -6,9 +6,55 @@ import {
   InputObjectTypeDefinitionNode,
   InputValueDefinitionNode,
 } from "graphql";
-import { FactoriesBaseVisitor, TypeValue } from "../FactoriesBaseVisitor";
+import {
+  DeclarationBlock,
+  indent,
+} from "@graphql-codegen/visitor-plugin-common";
+import { FactoriesBaseVisitor } from "../FactoriesBaseVisitor";
+
+interface TypeValue {
+  defaultValue: string;
+  isNullable: boolean;
+}
 
 export class FactoriesSchemaVisitor extends FactoriesBaseVisitor {
+  protected convertObjectType(
+    node: ObjectTypeDefinitionNode | InputObjectTypeDefinitionNode
+  ): string {
+    return new DeclarationBlock(this._declarationBlockConfig)
+      .export()
+      .asKind("function")
+      .withName(
+        `${this.convertFactoryName(
+          node
+        )}(props: Partial<${this.convertNameWithNamespace(
+          node
+        )}>): ${this.convertNameWithNamespace(node)}`
+      )
+      .withBlock(
+        [
+          indent("return {"),
+          node.kind === "ObjectTypeDefinition"
+            ? indent(indent(`__typename: "${node.name.value}",`))
+            : null,
+          ...(node.fields ?? []),
+          indent(indent("...props,")),
+          indent("};"),
+        ]
+          .filter(Boolean)
+          .join("\n")
+      ).string;
+  }
+
+  protected convertField(
+    node: FieldDefinitionNode | InputValueDefinitionNode
+  ): string {
+    const { defaultValue, isNullable } = node.type as unknown as TypeValue;
+    return indent(
+      indent(`${node.name.value}: ${isNullable ? "null" : defaultValue},`)
+    );
+  }
+
   NamedType(node: NamedTypeNode): TypeValue {
     return {
       defaultValue: this.getDefaultValue(node.name.value),

--- a/packages/graphql-codegen-factories/src/schema/__tests__/__snapshots__/plugin.ts.snap
+++ b/packages/graphql-codegen-factories/src/schema/__tests__/__snapshots__/plugin.ts.snap
@@ -14,6 +14,38 @@ Object {
 }
 `;
 
+exports[`plugin should create factories for unions 1`] = `
+Object {
+  "content": "export function createUserMock(props: Partial<User>): User {
+  return {
+    __typename: \\"User\\",
+    firstName: \\"\\",
+    lastName: \\"\\",
+    ...props,
+  };
+}
+
+export function createDroidMock(props: Partial<Droid>): Droid {
+  return {
+    __typename: \\"Droid\\",
+    codeName: \\"\\",
+    ...props,
+  };
+}
+
+export function createHumanoidMock({ __typename = \\"User\\", ...props }: Partial<Humanoid>): Humanoid {
+  switch(__typename) {
+    case \\"User\\":
+      return createUserMock({ __typename, ...props });
+    case \\"Droid\\":
+      return createDroidMock({ __typename, ...props });
+  }
+}
+",
+  "prepend": Array [],
+}
+`;
+
 exports[`plugin should create factories with built-in types 1`] = `
 Object {
   "content": "export function createUserMock(props: Partial<User>): User {

--- a/packages/graphql-codegen-factories/src/schema/__tests__/plugin.ts
+++ b/packages/graphql-codegen-factories/src/schema/__tests__/plugin.ts
@@ -158,4 +158,22 @@ describe("plugin", () => {
     });
     expect(output).toMatchSnapshot();
   });
+
+  it("should create factories for unions", async () => {
+    const schema = buildSchema(`
+      type User {
+        firstName: String!
+        lastName: String!
+      }
+
+      type Droid {
+        codeName: String!
+      }
+
+      union Humanoid = User | Droid
+    `);
+
+    const output = await plugin(schema, [], {});
+    expect(output).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Given the following schema:

```graphql
type Human {
  name: String!
}

type Droid {
  codeName: String!
}

type Humanoid = Human | Droid
```

The schema plugin was previously generating factories for `User` and `Droid` but not the `Humanoid` union. With this PR it's going to generate the following factory:

```typescript
export function createHumanoidMock({ __typename = "Human", ...props }: Partial<Humanoid>): Humanoid {
  switch(__typename) {
    case "Human":
      return createUserMock({ __typename, ...props });
    case "Droid":
      return createDroidMock({ __typename, ...props });
  }
}
```

This is going to be especially useful for the operations plugin to support inline fragments:

```graphql
query GetHumanoid {
  humanoid {
    ... on Human {
      name
    }
    ... on Droid {
      codeName
    }
  }
}
```