### PR TITLE
Rewrite operations plugin

### DIFF
--- a/docs/docs/configuration/operations.mdx
+++ b/docs/docs/configuration/operations.mdx
@@ -11,8 +11,10 @@ So for a query `GetUserQuery`, the corresponding factory will be named `createGe
 
 ## `config.schemaFactoriesPath`
 
-The operations' factories leverage the schema plugin's factories.
-So the path to the file containing the schema factories must be passed through this option.
+By default, this plugin assumes that the operations and schema factories are generated in the same file.
+The operations factories reference the schema's without importing them.
+
+If they are not generated in the same file, you need to provide the `schemaFactoriesPath`.
 
 ## `config.namespacedSchemaFactoriesImportName`
 

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -39,6 +39,7 @@ The next step is to add `graphql-codegen-factories/schema` to the list of plugin
 ```yml title="codegen.yml"
 overwrite: true
 schema: ./schema.graphql
+documents: ./**/*.graphql
 generates:
   ./types.ts:
     plugins:
@@ -59,22 +60,16 @@ The next step is to add `graphql-codegen-factories/operations` to the list of pl
 ```yml title="codegen.yml"
 overwrite: true
 schema: ./schema.graphql
-# highlight-start
 documents: ./**/*.graphql
-# highlight-end
 generates:
   ./types.ts:
     plugins:
       - typescript
       - graphql-codegen-factories/schema
-  # highlight-start
-  ./operations.ts:
-    config:
-      schemaFactoriesPath: ./types.ts
-    plugins:
       - typescript-operations
+      # highlight-start
       - graphql-codegen-factories/operations
-  # highlight-end
+      # highlight-end
 ```
 
 To access the full list of options, see the documentation for the [configuration](./configuration/operations.mdx).

--- a/examples/basic/codegen.yml
+++ b/examples/basic/codegen.yml
@@ -1,7 +1,13 @@
 overwrite: true
 schema: ./schema.graphql
+documents: ./**/*.graphql
 generates:
   ./generated/types.ts:
     plugins:
       - typescript
       - graphql-codegen-factories/schema
+      - typescript-operations
+      - graphql-codegen-factories/operations
+    config:
+      scalarDefaults:
+        Date: new Date()

--- a/examples/basic/findUser.graphql
+++ b/examples/basic/findUser.graphql
@@ -1,0 +1,11 @@
+query findUser($userId: ID!) {
+  user(id: $userId) {
+    ...UserFields
+  }
+}
+
+fragment UserFields on User {
+  id
+  username
+  role
+}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "^2.6.2",
     "@graphql-codegen/typescript": "^2.4.8",
+    "@graphql-codegen/typescript-operations": "^2.3.7",
     "@tsconfig/recommended": "^1.0.1",
     "graphql": "^16.3.0",
     "graphql-codegen-factories": "1.0.0-beta.4",

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -1,19 +1,44 @@
-type User {
-  id: ID!
-  username: String!
-}
+scalar Date
 
-type Image {
-  src: String!
+schema {
+  query: Query
 }
-
-type Video {
-  url: String!
-}
-
-union Media = Image | Video
 
 type Query {
-  loggedInUser: User!
-  media: Media!
+  me: User!
+  user(id: ID!): User
+  allUsers: [User]
+  search(term: String!): [SearchResult!]!
+  myChats: [Chat!]!
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+interface Node {
+  id: ID!
+}
+
+union SearchResult = User | Chat | ChatMessage
+
+type User implements Node {
+  id: ID!
+  username: String!
+  email: String!
+  role: Role!
+}
+
+type Chat implements Node {
+  id: ID!
+  users: [User!]!
+  messages: [ChatMessage!]!
+}
+
+type ChatMessage implements Node {
+  id: ID!
+  content: String!
+  time: Date!
+  user: User!
 }

--- a/examples/basic/search/search.graphql
+++ b/examples/basic/search/search.graphql
@@ -1,0 +1,25 @@
+query search($term: String!) {
+  search(term: $term) {
+    ... on Node {
+      id
+    }
+    ... on User {
+      fullname: username
+    }
+    ... on Chat {
+      users {
+        id
+      }
+    }
+    ... on ChatMessage {
+      ...ChatMessageFields
+    }
+  }
+}
+
+fragment ChatMessageFields on ChatMessage {
+  content
+  user {
+    email
+  }
+}

--- a/examples/usage-with-faker/codegen.yml
+++ b/examples/usage-with-faker/codegen.yml
@@ -11,3 +11,4 @@ generates:
       scalarDefaults:
         ID: "faker.random.alphaNumeric(16)"
         String: "faker.lorem.word()"
+        Date: "faker.date.past(1)"

--- a/examples/usage-with-faker/findUser.graphql
+++ b/examples/usage-with-faker/findUser.graphql
@@ -1,0 +1,11 @@
+query findUser($userId: ID!) {
+  user(id: $userId) {
+    ...UserFields
+  }
+}
+
+fragment UserFields on User {
+  id
+  username
+  role
+}

--- a/examples/usage-with-faker/schema.graphql
+++ b/examples/usage-with-faker/schema.graphql
@@ -1,9 +1,44 @@
-type User {
-  id: ID!
-  username: String!
+scalar Date
+
+schema {
+  query: Query
 }
 
 type Query {
-  loggedInUser: User!
+  me: User!
+  user(id: ID!): User
+  allUsers: [User]
+  search(term: String!): [SearchResult!]!
+  myChats: [Chat!]!
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+interface Node {
+  id: ID!
+}
+
+union SearchResult = User | Chat | ChatMessage
+
+type User implements Node {
+  id: ID!
+  username: String!
+  email: String!
+  role: Role!
+}
+
+type Chat implements Node {
+  id: ID!
   users: [User!]!
+  messages: [ChatMessage!]!
+}
+
+type ChatMessage implements Node {
+  id: ID!
+  content: String!
+  time: Date!
+  user: User!
 }

--- a/examples/usage-with-faker/search/search.graphql
+++ b/examples/usage-with-faker/search/search.graphql
@@ -1,0 +1,25 @@
+query search($term: String!) {
+  search(term: $term) {
+    ... on Node {
+      id
+    }
+    ... on User {
+      fullname: username
+    }
+    ... on Chat {
+      users {
+        id
+      }
+    }
+    ... on ChatMessage {
+      ...ChatMessageFields
+    }
+  }
+}
+
+fragment ChatMessageFields on ChatMessage {
+  content
+  user {
+    email
+  }
+}

--- a/examples/usage-with-near-operation-file-preset/GetLoggedInUser.graphql
+++ b/examples/usage-with-near-operation-file-preset/GetLoggedInUser.graphql
@@ -1,6 +1,0 @@
-query GetLoggedInUser {
-  loggedInUser {
-    id
-    username
-  }
-}

--- a/examples/usage-with-near-operation-file-preset/codegen.yml
+++ b/examples/usage-with-near-operation-file-preset/codegen.yml
@@ -10,6 +10,8 @@ generates:
       - graphql-codegen-factories/schema
     config:
       typesPath: ./types
+      scalarDefaults:
+        Date: new Date()
   ./:
     preset: near-operation-file
     presetConfig:

--- a/examples/usage-with-near-operation-file-preset/findUser.graphql
+++ b/examples/usage-with-near-operation-file-preset/findUser.graphql
@@ -1,0 +1,11 @@
+query findUser($userId: ID!) {
+  user(id: $userId) {
+    ...UserFields
+  }
+}
+
+fragment UserFields on User {
+  id
+  username
+  role
+}

--- a/examples/usage-with-near-operation-file-preset/nestedOperation/GetUsers.graphql
+++ b/examples/usage-with-near-operation-file-preset/nestedOperation/GetUsers.graphql
@@ -1,5 +1,0 @@
-query GetUsers {
-  users {
-    id
-  }
-}

--- a/examples/usage-with-near-operation-file-preset/schema.graphql
+++ b/examples/usage-with-near-operation-file-preset/schema.graphql
@@ -1,9 +1,44 @@
-type User {
-  id: ID!
-  username: String!
+scalar Date
+
+schema {
+  query: Query
 }
 
 type Query {
-  loggedInUser: User!
+  me: User!
+  user(id: ID!): User
+  allUsers: [User]
+  search(term: String!): [SearchResult!]!
+  myChats: [Chat!]!
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+
+interface Node {
+  id: ID!
+}
+
+union SearchResult = User | Chat | ChatMessage
+
+type User implements Node {
+  id: ID!
+  username: String!
+  email: String!
+  role: Role!
+}
+
+type Chat implements Node {
+  id: ID!
   users: [User!]!
+  messages: [ChatMessage!]!
+}
+
+type ChatMessage implements Node {
+  id: ID!
+  content: String!
+  time: Date!
+  user: User!
 }

--- a/examples/usage-with-near-operation-file-preset/search/search.graphql
+++ b/examples/usage-with-near-operation-file-preset/search/search.graphql
@@ -1,0 +1,25 @@
+query search($term: String!) {
+  search(term: $term) {
+    ... on Node {
+      id
+    }
+    ... on User {
+      fullname: username
+    }
+    ... on Chat {
+      users {
+        id
+      }
+    }
+    ... on ChatMessage {
+      ...ChatMessageFields
+    }
+  }
+}
+
+fragment ChatMessageFields on ChatMessage {
+  content
+  user {
+    email
+  }
+}

--- a/packages/graphql-codegen-factories/src/operations/__tests__/__snapshots__/plugin.ts.snap
+++ b/packages/graphql-codegen-factories/src/operations/__tests__/__snapshots__/plugin.ts.snap
@@ -1,27 +1,267 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`plugin should generate factory for a simple operation 1`] = `
+exports[`plugin should add interface's selections to the matching types 1`] = `
 Object {
-  "content": "export function createCreateUserMutationMock(props: Partial<CreateUserMutation>): CreateUserMutation {
+  "content": "export function createGetMediasQueryMock(props: Partial<GetMediasQuery> = {}): GetMediasQuery {
+  return {
+    __typename: \\"Query\\",
+    medias: [],
+    ...props,
+  };
+}
+
+export function createGetMediasQueryMock_medias(props: Partial<GetMediasQuery[\\"medias\\"][number]> = {}): GetMediasQuery[\\"medias\\"][number] {
   switch(props.__typename) {
-    case \\"Mutation\\": {
-      return { createUser: createCreateUserMutationMock_createUser({}), ...props };
-    }
+    case \\"Image\\":
+      return createGetMediasQueryMock_medias_Image(props);
+    case \\"Audio\\":
+      return createGetMediasQueryMock_medias_Audio(props);
+    case \\"Video\\":
+      return createGetMediasQueryMock_medias_Video(props);
     case undefined:
     default:
-      return createCreateUserMutationMock({ ...props, __typename: \\"Mutation\\" });
+      return createGetMediasQueryMock_medias({ ...props, __typename: \\"Image\\" })
   }
 }
-export function createCreateUserMutationMock_createUser(props: Partial<CreateUserMutation[\\"createUser\\"]>): CreateUserMutation[\\"createUser\\"] {
+
+export function createGetMediasQueryMock_medias_Image(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Image\\" }, { __typename: \\"Image\\" }>> = {}): Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Image\\" }, { __typename: \\"Image\\" }> {
+  const image = schemaFactories.createImageMock({
+    path: props.path,
+    width: props.width,
+  });
+  return {
+    __typename: \\"Image\\",
+    path: image.path,
+    width: image.width,
+    ...props,
+  };
+}
+
+export function createGetMediasQueryMock_medias_Audio(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Audio\\" }, { __typename: \\"Audio\\" }>> = {}): Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Audio\\" }, { __typename: \\"Audio\\" }> {
+  const audio = schemaFactories.createAudioMock({
+    path: props.path,
+    length: props.length,
+  });
+  return {
+    __typename: \\"Audio\\",
+    path: audio.path,
+    length: audio.length,
+    ...props,
+  };
+}
+
+export function createGetMediasQueryMock_medias_Video(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Video\\" }, { __typename: \\"Video\\" }>> = {}): Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Video\\" }, { __typename: \\"Video\\" }> {
+  const video = schemaFactories.createVideoMock({
+    url: props.url,
+    length: props.length,
+  });
+  return {
+    __typename: \\"Video\\",
+    url: video.url,
+    length: video.length,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should dedupe fields 1`] = `
+Object {
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: null,
+    ...props,
+  };
+}
+
+export function createGetMeQueryMock_me(props: Partial<NonNullable<GetMeQuery[\\"me\\"]>> = {}): NonNullable<GetMeQuery[\\"me\\"]> {
   switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, ...props };
-    }
+    case \\"User\\":
+      return createGetMeQueryMock_me_User(props);
+    case \\"Admin\\":
+      return createGetMeQueryMock_me_Admin(props);
     case undefined:
     default:
-      return createCreateUserMutationMock_createUser({ ...props, __typename: \\"User\\" });
+      return createGetMeQueryMock_me({ ...props, __typename: \\"User\\" })
   }
+}
+
+export function createGetMeQueryMock_me_User(props: Partial<Extract<NonNullable<GetMeQuery[\\"me\\"]> & { __typename: \\"User\\" }, { __typename: \\"User\\" }>> = {}): Extract<NonNullable<GetMeQuery[\\"me\\"]> & { __typename: \\"User\\" }, { __typename: \\"User\\" }> {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+    id: props.userId,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    userId: user.id,
+    ...props,
+  };
+}
+
+export function createGetMeQueryMock_me_Admin(props: Partial<Extract<NonNullable<GetMeQuery[\\"me\\"]> & { __typename: \\"Admin\\" }, { __typename: \\"Admin\\" }>> = {}): Extract<NonNullable<GetMeQuery[\\"me\\"]> & { __typename: \\"Admin\\" }, { __typename: \\"Admin\\" }> {
+  const admin = schemaFactories.createAdminMock({
+    id: props.id,
+  });
+  return {
+    __typename: \\"Admin\\",
+    id: admin.id,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should generate factory for a simple operation 1`] = `
+Object {
+  "content": "export function createCreateUserMutationMock(props: Partial<CreateUserMutation> = {}): CreateUserMutation {
+  return {
+    __typename: \\"Mutation\\",
+    createUser: createCreateUserMutationMock_createUser({}),
+    ...props,
+  };
+}
+
+export function createCreateUserMutationMock_createUser(props: Partial<CreateUserMutation[\\"createUser\\"]> = {}): CreateUserMutation[\\"createUser\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should generate union factory even when querying one type from the union 1`] = `
+Object {
+  "content": "export function createGetMediasQueryMock(props: Partial<GetMediasQuery> = {}): GetMediasQuery {
+  return {
+    __typename: \\"Query\\",
+    medias: [],
+    ...props,
+  };
+}
+
+export function createGetMediasQueryMock_medias(props: Partial<GetMediasQuery[\\"medias\\"][number]> = {}): GetMediasQuery[\\"medias\\"][number] {
+  switch(props.__typename) {
+    case \\"Audio\\":
+      return createGetMediasQueryMock_medias_Audio(props);
+    case undefined:
+    default:
+      return createGetMediasQueryMock_medias({ ...props, __typename: \\"Audio\\" })
+  }
+}
+
+export function createGetMediasQueryMock_medias_Audio(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Audio\\" }, { __typename: \\"Audio\\" }>> = {}): Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Audio\\" }, { __typename: \\"Audio\\" }> {
+  const audio = schemaFactories.createAudioMock({
+    length: props.length,
+  });
+  return {
+    __typename: \\"Audio\\",
+    length: audio.length,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should merge fragments and inline fragments with the same type condition 1`] = `
+Object {
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
+}
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should merge fragments with the same type condition 1`] = `
+Object {
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
+}
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should merge inline fragments with the same type condition 1`] = `
+Object {
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
+}
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -31,26 +271,25 @@ export function createCreateUserMutationMock_createUser(props: Partial<CreateUse
 
 exports[`plugin should support aliases 1`] = `
 Object {
-  "content": "export function createCreateUserMutationMock(props: Partial<CreateUserMutation>): CreateUserMutation {
-  switch(props.__typename) {
-    case \\"Mutation\\": {
-      return { createUser: createCreateUserMutationMock_createUser({}), ...props };
-    }
-    case undefined:
-    default:
-      return createCreateUserMutationMock({ ...props, __typename: \\"Mutation\\" });
-  }
+  "content": "export function createCreateUserMutationMock(props: Partial<CreateUserMutation> = {}): CreateUserMutation {
+  return {
+    __typename: \\"Mutation\\",
+    createUser: createCreateUserMutationMock_createUser({}),
+    ...props,
+  };
 }
-export function createCreateUserMutationMock_createUser(props: Partial<CreateUserMutation[\\"createUser\\"]>): CreateUserMutation[\\"createUser\\"] {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username: email } = schemaFactories.createUserMock({ id: props.id, username: props.email });
-      return { id, email, ...props };
-    }
-    case undefined:
-    default:
-      return createCreateUserMutationMock_createUser({ ...props, __typename: \\"User\\" });
-  }
+
+export function createCreateUserMutationMock_createUser(props: Partial<CreateUserMutation[\\"createUser\\"]> = {}): CreateUserMutation[\\"createUser\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.email,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    email: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -60,36 +299,25 @@ export function createCreateUserMutationMock_createUser(props: Partial<CreateUse
 
 exports[`plugin should support external fragments 1`] = `
 Object {
-  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery>): GetMeQuery {
-  switch(props.__typename) {
-    case \\"Query\\": {
-      return { me: createGetMeQueryMock_me({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock({ ...props, __typename: \\"Query\\" });
-  }
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
 }
-export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]>): GetMeQuery[\\"me\\"] {
-  switch(props.__typename) {
-    case \\"User\\": {
-      return { ...createGetMeQueryMock_me_User({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me({ ...props, __typename: \\"User\\" });
-  }
-}
-export function createGetMeQueryMock_me_User(props: Partial<Extract<GetMeQuery[\\"me\\"], { __typename: \\"User\\" }>>): Extract<GetMeQuery[\\"me\\"], { __typename: \\"User\\" }> {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me_User({ ...props, __typename: \\"User\\" });
-  }
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -99,36 +327,25 @@ export function createGetMeQueryMock_me_User(props: Partial<Extract<GetMeQuery[\
 
 exports[`plugin should support fragments 1`] = `
 Object {
-  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery>): GetMeQuery {
-  switch(props.__typename) {
-    case \\"Query\\": {
-      return { me: createGetMeQueryMock_me({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock({ ...props, __typename: \\"Query\\" });
-  }
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
 }
-export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]>): GetMeQuery[\\"me\\"] {
-  switch(props.__typename) {
-    case \\"User\\": {
-      return { ...createGetMeQueryMock_me_User({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me({ ...props, __typename: \\"User\\" });
-  }
-}
-export function createGetMeQueryMock_me_User(props: Partial<Extract<GetMeQuery[\\"me\\"], { __typename: \\"User\\" }>>): Extract<GetMeQuery[\\"me\\"], { __typename: \\"User\\" }> {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me_User({ ...props, __typename: \\"User\\" });
-  }
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -138,36 +355,25 @@ export function createGetMeQueryMock_me_User(props: Partial<Extract<GetMeQuery[\
 
 exports[`plugin should support inline fragments 1`] = `
 Object {
-  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery>): GetMeQuery {
-  switch(props.__typename) {
-    case \\"Query\\": {
-      return { me: createGetMeQueryMock_me({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock({ ...props, __typename: \\"Query\\" });
-  }
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
 }
-export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]>): GetMeQuery[\\"me\\"] {
-  switch(props.__typename) {
-    case \\"User\\": {
-      return { ...createGetMeQueryMock_me_User({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me({ ...props, __typename: \\"User\\" });
-  }
-}
-export function createGetMeQueryMock_me_User(props: Partial<Extract<GetMeQuery[\\"me\\"], { __typename: \\"User\\" }>>): Extract<GetMeQuery[\\"me\\"], { __typename: \\"User\\" }> {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me_User({ ...props, __typename: \\"User\\" });
-  }
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -177,26 +383,25 @@ export function createGetMeQueryMock_me_User(props: Partial<Extract<GetMeQuery[\
 
 exports[`plugin should support lists 1`] = `
 Object {
-  "content": "export function createGetUsersQueryMock(props: Partial<GetUsersQuery>): GetUsersQuery {
-  switch(props.__typename) {
-    case \\"Query\\": {
-      return { users: [], ...props };
-    }
-    case undefined:
-    default:
-      return createGetUsersQueryMock({ ...props, __typename: \\"Query\\" });
-  }
+  "content": "export function createGetUsersQueryMock(props: Partial<GetUsersQuery> = {}): GetUsersQuery {
+  return {
+    __typename: \\"Query\\",
+    users: [],
+    ...props,
+  };
 }
-export function createGetUsersQueryMock_users(props: Partial<GetUsersQuery[\\"users\\"][number]>): GetUsersQuery[\\"users\\"][number] {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, ...props };
-    }
-    case undefined:
-    default:
-      return createGetUsersQueryMock_users({ ...props, __typename: \\"User\\" });
-  }
+
+export function createGetUsersQueryMock_users(props: Partial<GetUsersQuery[\\"users\\"][number]> = {}): GetUsersQuery[\\"users\\"][number] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -206,37 +411,37 @@ export function createGetUsersQueryMock_users(props: Partial<GetUsersQuery[\\"us
 
 exports[`plugin should support nested selections 1`] = `
 Object {
-  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery>): GetMeQuery {
-  switch(props.__typename) {
-    case \\"Query\\": {
-      return { me: null, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock({ ...props, __typename: \\"Query\\" });
-  }
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: null,
+    ...props,
+  };
 }
-export function createGetMeQueryMock_me(props: Partial<NonNull<GetMeQuery[\\"me\\"]>>): NonNull<GetMeQuery[\\"me\\"]> {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, followers: null, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me({ ...props, __typename: \\"User\\" });
-  }
+
+export function createGetMeQueryMock_me(props: Partial<NonNullable<GetMeQuery[\\"me\\"]>> = {}): NonNullable<GetMeQuery[\\"me\\"]> {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    followers: null,
+    ...props,
+  };
 }
-export function createGetMeQueryMock_me_followers(props: Partial<NonNull<NonNull<NonNull<GetMeQuery[\\"me\\"]>[\\"followers\\"]>[number]>>): NonNull<NonNull<NonNull<GetMeQuery[\\"me\\"]>[\\"followers\\"]>[number]> {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id } = schemaFactories.createUserMock({ id: props.id });
-      return { id, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMeQueryMock_me_followers({ ...props, __typename: \\"User\\" });
-  }
+
+export function createGetMeQueryMock_me_followers(props: Partial<NonNullable<NonNullable<NonNullable<GetMeQuery[\\"me\\"]>[\\"followers\\"]>[number]>> = {}): NonNullable<NonNullable<NonNullable<GetMeQuery[\\"me\\"]>[\\"followers\\"]>[number]> {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -246,72 +451,70 @@ export function createGetMeQueryMock_me_followers(props: Partial<NonNull<NonNull
 
 exports[`plugin should support unions 1`] = `
 Object {
-  "content": "export function createGetMediasQueryMock(props: Partial<GetMediasQuery>): GetMediasQuery {
+  "content": "export function createGetMediasQueryMock(props: Partial<GetMediasQuery> = {}): GetMediasQuery {
+  return {
+    __typename: \\"Query\\",
+    medias: [],
+    ...props,
+  };
+}
+
+export function createGetMediasQueryMock_medias(props: Partial<GetMediasQuery[\\"medias\\"][number]> = {}): GetMediasQuery[\\"medias\\"][number] {
   switch(props.__typename) {
-    case \\"Query\\": {
-      return { medias: [], ...props };
-    }
+    case \\"Image\\":
+      return createGetMediasQueryMock_medias_Image(props);
+    case \\"Video\\":
+      return createGetMediasQueryMock_medias_Video(props);
     case undefined:
     default:
-      return createGetMediasQueryMock({ ...props, __typename: \\"Query\\" });
+      return createGetMediasQueryMock_medias({ ...props, __typename: \\"Image\\" })
   }
 }
-export function createGetMediasQueryMock_medias(props: Partial<GetMediasQuery[\\"medias\\"][number]>): GetMediasQuery[\\"medias\\"][number] {
-  switch(props.__typename) {
-    case \\"Image\\": {
-      return { ...createGetMediasQueryMock_medias_Image({}), ...props };
-    }
-    case \\"Video\\": {
-      return { ...createGetMediasQueryMock_medias_Video({}), ...props };
-    }
-    case undefined:
-    default:
-      return createGetMediasQueryMock_medias({ ...props, __typename: \\"Image\\" });
-  }
+
+export function createGetMediasQueryMock_medias_Image(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Image\\" }, { __typename: \\"Image\\" }>> = {}): Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Image\\" }, { __typename: \\"Image\\" }> {
+  const image = schemaFactories.createImageMock({
+    src: props.src,
+  });
+  return {
+    __typename: \\"Image\\",
+    src: image.src,
+    dimensions: null,
+    ...props,
+  };
 }
-export function createGetMediasQueryMock_medias_Image(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Image\\" }>>): Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Image\\" }> {
-  switch(props.__typename) {
-    case \\"Image\\": {
-      const { src } = schemaFactories.createImageMock({ src: props.src });
-      return { src, dimensions: null, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMediasQueryMock_medias_Image({ ...props, __typename: \\"Image\\" });
-  }
+
+export function createGetMediasQueryMock_medias_Image_dimensions(props: Partial<NonNullable<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Image\\" }, { __typename: \\"Image\\" }>[\\"dimensions\\"]>> = {}): NonNullable<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Image\\" }, { __typename: \\"Image\\" }>[\\"dimensions\\"]> {
+  const imageDimensions = schemaFactories.createImageDimensionsMock({
+    width: props.width,
+  });
+  return {
+    __typename: \\"ImageDimensions\\",
+    width: imageDimensions.width,
+    ...props,
+  };
 }
-export function createGetMediasQueryMock_medias_Image_dimensions(props: Partial<NonNull<Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Image\\" }>[\\"dimensions\\"]>>): NonNull<Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Image\\" }>[\\"dimensions\\"]> {
-  switch(props.__typename) {
-    case \\"ImageDimensions\\": {
-      const { width } = schemaFactories.createImageDimensionsMock({ width: props.width });
-      return { width, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMediasQueryMock_medias_Image_dimensions({ ...props, __typename: \\"ImageDimensions\\" });
-  }
+
+export function createGetMediasQueryMock_medias_Video(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Video\\" }, { __typename: \\"Video\\" }>> = {}): Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Video\\" }, { __typename: \\"Video\\" }> {
+  const video = schemaFactories.createVideoMock({
+    href: props.href,
+  });
+  return {
+    __typename: \\"Video\\",
+    href: video.href,
+    dimensions: null,
+    ...props,
+  };
 }
-export function createGetMediasQueryMock_medias_Video(props: Partial<Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Video\\" }>>): Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Video\\" }> {
-  switch(props.__typename) {
-    case \\"Video\\": {
-      const { href } = schemaFactories.createVideoMock({ href: props.href });
-      return { href, dimensions: null, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMediasQueryMock_medias_Video({ ...props, __typename: \\"Video\\" });
-  }
-}
-export function createGetMediasQueryMock_medias_Video_dimensions(props: Partial<NonNull<Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Video\\" }>[\\"dimensions\\"]>>): NonNull<Extract<GetMediasQuery[\\"medias\\"][number], { __typename: \\"Video\\" }>[\\"dimensions\\"]> {
-  switch(props.__typename) {
-    case \\"ImageDimensions\\": {
-      const { height } = schemaFactories.createImageDimensionsMock({ height: props.height });
-      return { height, ...props };
-    }
-    case undefined:
-    default:
-      return createGetMediasQueryMock_medias_Video_dimensions({ ...props, __typename: \\"ImageDimensions\\" });
-  }
+
+export function createGetMediasQueryMock_medias_Video_dimensions(props: Partial<NonNullable<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Video\\" }, { __typename: \\"Video\\" }>[\\"dimensions\\"]>> = {}): NonNullable<Extract<GetMediasQuery[\\"medias\\"][number] & { __typename: \\"Video\\" }, { __typename: \\"Video\\" }>[\\"dimensions\\"]> {
+  const imageDimensions = schemaFactories.createImageDimensionsMock({
+    height: props.height,
+  });
+  return {
+    __typename: \\"ImageDimensions\\",
+    height: imageDimensions.height,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",
@@ -321,26 +524,53 @@ export function createGetMediasQueryMock_medias_Video_dimensions(props: Partial<
 
 exports[`plugin should support unnamed operations 1`] = `
 Object {
-  "content": "export function createUnnamed_1_QueryMock(props: Partial<Unnamed_1_Query>): Unnamed_1_Query {
-  switch(props.__typename) {
-    case \\"Query\\": {
-      return { me: null, ...props };
-    }
-    case undefined:
-    default:
-      return createUnnamed_1_QueryMock({ ...props, __typename: \\"Query\\" });
-  }
+  "content": "export function createUnnamed_1_QueryMock(props: Partial<Unnamed_1_Query> = {}): Unnamed_1_Query {
+  return {
+    __typename: \\"Query\\",
+    me: null,
+    ...props,
+  };
 }
-export function createUnnamed_1_QueryMock_me(props: Partial<NonNull<Unnamed_1_Query[\\"me\\"]>>): NonNull<Unnamed_1_Query[\\"me\\"]> {
-  switch(props.__typename) {
-    case \\"User\\": {
-      const { id, username } = schemaFactories.createUserMock({ id: props.id, username: props.username });
-      return { id, username, ...props };
-    }
-    case undefined:
-    default:
-      return createUnnamed_1_QueryMock_me({ ...props, __typename: \\"User\\" });
-  }
+
+export function createUnnamed_1_QueryMock_me(props: Partial<NonNullable<Unnamed_1_Query[\\"me\\"]>> = {}): NonNullable<Unnamed_1_Query[\\"me\\"]> {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
+exports[`plugin should unwrap inline fragments without a type condition 1`] = `
+Object {
+  "content": "export function createGetMeQueryMock(props: Partial<GetMeQuery> = {}): GetMeQuery {
+  return {
+    __typename: \\"Query\\",
+    me: createGetMeQueryMock_me({}),
+    ...props,
+  };
+}
+
+export function createGetMeQueryMock_me(props: Partial<GetMeQuery[\\"me\\"]> = {}): GetMeQuery[\\"me\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
 }",
   "prepend": Array [
     "import * as schemaFactories from \\"./factories\\";",

--- a/packages/graphql-codegen-factories/src/schema/FactoriesSchemaVisitor.ts
+++ b/packages/graphql-codegen-factories/src/schema/FactoriesSchemaVisitor.ts
@@ -320,7 +320,7 @@ export class FactoriesSchemaVisitor extends FactoriesBaseVisitor<
           node.name.value
         )}(props: Partial<${this.convertNameWithTypesNamespace(
           node.name.value
-        )}>): ${this.convertNameWithTypesNamespace(node.name.value)}`
+        )}> = {}): ${this.convertNameWithTypesNamespace(node.name.value)}`
       )
       .withBlock(
         [

--- a/packages/graphql-codegen-factories/src/schema/__tests__/__snapshots__/plugin.ts.snap
+++ b/packages/graphql-codegen-factories/src/schema/__tests__/__snapshots__/plugin.ts.snap
@@ -181,6 +181,21 @@ Object {
 }
 `;
 
+exports[`plugin should support interfaces 1`] = `
+Object {
+  "content": "export function createUserMock(props: Partial<User>): User {
+  return {
+    __typename: \\"User\\",
+    id: \\"\\",
+    username: \\"\\",
+    ...props,
+  };
+}
+",
+  "prepend": Array [],
+}
+`;
+
 exports[`plugin should use enums as types 1`] = `
 Object {
   "content": "export function createUserMock(props: Partial<User> = {}): User {

--- a/packages/graphql-codegen-factories/src/schema/__tests__/__snapshots__/plugin.ts.snap
+++ b/packages/graphql-codegen-factories/src/schema/__tests__/__snapshots__/plugin.ts.snap
@@ -63,7 +63,7 @@ export function createDroidMock(props: Partial<Droid> = {}): Droid {
   };
 }
 
-export function createHumanoidMock(props: Partial<Humanoid>): Humanoid {
+export function createHumanoidMock(props: Partial<Humanoid> = {}): Humanoid {
   switch(props.__typename) {
     case \\"User\\":
       return createUserMock(props);
@@ -183,7 +183,7 @@ Object {
 
 exports[`plugin should support interfaces 1`] = `
 Object {
-  "content": "export function createUserMock(props: Partial<User>): User {
+  "content": "export function createUserMock(props: Partial<User> = {}): User {
   return {
     __typename: \\"User\\",
     id: \\"\\",

--- a/packages/graphql-codegen-factories/src/schema/__tests__/plugin.ts
+++ b/packages/graphql-codegen-factories/src/schema/__tests__/plugin.ts
@@ -176,4 +176,19 @@ describe("plugin", () => {
     const output = await plugin(schema, [], {});
     expect(output).toMatchSnapshot();
   });
+
+  it("should support interfaces", async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      interface Node {
+        id: ID!
+      }
+      type User implements Node {
+        id: ID!
+        username: String!
+      }
+    `);
+
+    const output = await plugin(schema, [], {});
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,6 +1831,28 @@
     auto-bind "~4.0.0"
     tslib "~2.3.0"
 
+"@graphql-codegen/typescript-operations@^2.3.7":
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.3.7.tgz#eddbac9fcbc6ad017b1f9c4760785207827f09db"
+  integrity sha512-XRArQ+Mk7NAikaRVM3+ctnskPTtucICen/KxrdBOzM+V9CXKkdXg2leu9i5ofoYg0oBMDKJQC4vN2/gKPyfHhg==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.4.0"
+    "@graphql-codegen/typescript" "^2.4.10"
+    "@graphql-codegen/visitor-plugin-common" "2.7.6"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/typescript@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.4.10.tgz#245512826fc0c6663756cca6359ac4d45719af5f"
+  integrity sha512-Wr/GzYrpY8d8I9+ZFSkNefOpYaMtBL2s2E79IoEOLAqXHUWxM0reBwkEk4oHtLw27AmaXgngajPFPaO5QAhotQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.4.0"
+    "@graphql-codegen/schema-ast" "^2.4.1"
+    "@graphql-codegen/visitor-plugin-common" "2.7.6"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
 "@graphql-codegen/typescript@^2.4.8":
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.4.8.tgz#e8110baba9713cde72d57a5c95aa27400363ed9a"
@@ -1857,6 +1879,22 @@
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
     tslib "~2.3.0"
+
+"@graphql-codegen/visitor-plugin-common@2.7.6":
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.7.6.tgz#70be729551fedc090d69fe4f16272bccf5222d28"
+  integrity sha512-XHeopd8z5UE2alv8nn2LrF+qpfRpldeqHOwrmLmlzyCWcuz5vMiZ08CgtE03micQNQJg5s8Z9m72S3FrvBUoAA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.4.0"
+    "@graphql-tools/optimize" "^1.0.1"
+    "@graphql-tools/relay-operation-optimizer" "^6.3.7"
+    "@graphql-tools/utils" "^8.3.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.14"
+    dependency-graph "^0.11.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
 
 "@graphql-tools/apollo-engine-loader@^7.0.5":
   version "7.2.6"
@@ -10371,6 +10409,11 @@ tslib@^2, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, 
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
The previous iteration of the operations plugin brought us closer to a great developer experience. It has some serious drawbacks though, mostly due to the fact that it is heavily based on the operation's selection. The result is that the factories generated are hard to predict for the developer as they depend on the operation's implementation details.

That, plus the fact it has some bugs:

- Fragments with the same type condition results in two factories with the same name.
- Inline fragments with the same type condition results in two factories with the same name.
- Inline fragments without a type condition results in a factory named "undefined".

All in all, it would offer a better experience if was generating more predictable factories that are not based on the operation's selections.

This PR does that by rewriting the operations plugin to not be based so much on the selections but rather on the objects' shape. So for example those queries:

```graphql
query GetUser {
  user {
    ...on User {
      username
    }
  }
}
```

```graphql
query GetUser {
  user {
    username
  }
}
```

Would result in the same factories being generated, regardless of the fact that one is using inline fragment and not the other.