### PR TITLE
fix: resolve `__typename` via TypeNameMetaFieldDef in operations plugin

### DIFF
--- a/packages/graphql-codegen-factories/src/operations/FactoriesOperationsVisitor.ts
+++ b/packages/graphql-codegen-factories/src/operations/FactoriesOperationsVisitor.ts
@@ -198,13 +198,27 @@ export class FactoriesOperationsVisitor extends FactoriesBaseVisitor<
     }
 
     if (selection.kind === Kind.FIELD) {
-      // `__typename` is a meta-field defined by the spec and is not present in
-      // getFields(); resolve it via graphql's TypeNameMetaFieldDef so selecting
-      // it (e.g. in a fragment) doesn't crash.
-      const field =
-        selection.name.value === TypeNameMetaFieldDef.name
-          ? TypeNameMetaFieldDef
-          : (parent as GraphQLObjectType).getFields()[selection.name.value];
+      if (selection.name.value === TypeNameMetaFieldDef.name) {
+        // `__typename` is not present in getFields(); and since it's always included,
+        // we can safely ignore it here
+        return [];
+      }
+
+      if (isUnionType(parent)) {
+        // Union types don't expose fields directly (getFields() doesn't exist on them)
+        throw new Error(
+          `Field "${selection.name.value}" cannot be selected on union type "${parent.name}" without an inline fragment`
+        );
+      }
+
+      const field = parent.getFields()[selection.name.value];
+
+      if (field == null) {
+        throw new Error(
+          `Field "${selection.name.value}" not found on type "${parent.name}"`
+        );
+      }
+
       const type = field.type;
       return [
         {

--- a/packages/graphql-codegen-factories/src/operations/FactoriesOperationsVisitor.ts
+++ b/packages/graphql-codegen-factories/src/operations/FactoriesOperationsVisitor.ts
@@ -16,6 +16,7 @@ import {
   Kind,
   OperationDefinitionNode,
   SelectionNode,
+  TypeNameMetaFieldDef,
 } from "graphql";
 import {
   FactoriesBaseVisitor,
@@ -197,9 +198,14 @@ export class FactoriesOperationsVisitor extends FactoriesBaseVisitor<
     }
 
     if (selection.kind === Kind.FIELD) {
-      const type = (parent as GraphQLObjectType).getFields()[
-        selection.name.value
-      ].type;
+      // `__typename` is a meta-field defined by the spec and is not present in
+      // getFields(); resolve it via graphql's TypeNameMetaFieldDef so selecting
+      // it (e.g. in a fragment) doesn't crash.
+      const field =
+        selection.name.value === TypeNameMetaFieldDef.name
+          ? TypeNameMetaFieldDef
+          : (parent as GraphQLObjectType).getFields()[selection.name.value];
+      const type = field.type;
       return [
         {
           name: selection.name.value,

--- a/packages/graphql-codegen-factories/src/operations/__tests__/__snapshots__/plugin.ts.snap
+++ b/packages/graphql-codegen-factories/src/operations/__tests__/__snapshots__/plugin.ts.snap
@@ -475,6 +475,34 @@ export function createGetMeQueryMock_me_followers(props: Partial<NonNullable<Non
 }
 `;
 
+exports[`plugin should support selecting the __typename meta-field 1`] = `
+Object {
+  "content": "export function createGetUserQueryMock(props: Partial<GetUserQuery> = {}): GetUserQuery {
+  return {
+    __typename: \\"Query\\",
+    user: createGetUserQueryMock_user({}),
+    ...props,
+  };
+}
+
+export function createGetUserQueryMock_user(props: Partial<GetUserQuery[\\"user\\"]> = {}): GetUserQuery[\\"user\\"] {
+  const user = schemaFactories.createUserMock({
+    id: props.id,
+    username: props.username,
+  });
+  return {
+    __typename: \\"User\\",
+    id: user.id,
+    username: user.username,
+    ...props,
+  };
+}",
+  "prepend": Array [
+    "import * as schemaFactories from \\"./factories\\";",
+  ],
+}
+`;
+
 exports[`plugin should support unions 1`] = `
 Object {
   "content": "export function createGetMediasQueryMock(props: Partial<GetMediasQuery> = {}): GetMediasQuery {

--- a/packages/graphql-codegen-factories/src/operations/__tests__/plugin.ts
+++ b/packages/graphql-codegen-factories/src/operations/__tests__/plugin.ts
@@ -617,4 +617,33 @@ describe("plugin", () => {
     );
     expect(output).toMatchSnapshot();
   });
+
+  it("should support selecting the __typename meta-field", async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID!
+        username: String!
+      }
+
+      type Query {
+        user: User!
+      }
+    `);
+    const ast = parse(/* GraphQL */ `
+      query GetUser {
+        user {
+          __typename
+          id
+          username
+        }
+      }
+    `);
+
+    const output = await plugin(
+      schema,
+      [{ location: "GetUser.graphql", document: ast }],
+      { schemaFactoriesPath: "./factories" }
+    );
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/graphql-codegen-factories/src/operations/__tests__/plugin.ts
+++ b/packages/graphql-codegen-factories/src/operations/__tests__/plugin.ts
@@ -646,4 +646,63 @@ describe("plugin", () => {
     );
     expect(output).toMatchSnapshot();
   });
+
+  it("should throw a descriptive error when selecting a field that does not exist on the type", async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID!
+      }
+
+      type Query {
+        user: User!
+      }
+    `);
+    const ast = parse(/* GraphQL */ `
+      query GetUser {
+        user {
+          id
+          username
+        }
+      }
+    `);
+
+    expect(() =>
+      plugin(schema, [{ location: "GetUser.graphql", document: ast }], {
+        schemaFactoriesPath: "./factories",
+      })
+    ).toThrow('Field "username" not found on type "User"');
+  });
+
+  it("should throw a descriptive error when selecting a field on a union without an inline fragment", async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Image {
+        src: String!
+      }
+
+      type Video {
+        href: String!
+      }
+
+      union Media = Image | Video
+
+      type Query {
+        media: Media!
+      }
+    `);
+    const ast = parse(/* GraphQL */ `
+      query GetMedia {
+        media {
+          src
+        }
+      }
+    `);
+
+    expect(() =>
+      plugin(schema, [{ location: "GetMedia.graphql", document: ast }], {
+        schemaFactoriesPath: "./factories",
+      })
+    ).toThrow(
+      'Field "src" cannot be selected on union type "Media" without an inline fragment'
+    );
+  });
 });


### PR DESCRIPTION
## What

The operations plugin crashes with `Cannot read properties of undefined (reading 'type')` when an operation/fragment selects the `__typename` meta-field:

```graphql
query GetUser {
  user {
    __typename   # 💥
    id
  }
}
```

`__typename` is a spec meta-field selectable on any object/interface/union type, but graphql-js's `getFields()` never includes it, so:

```ts
const type = (parent as GraphQLObjectType).getFields()[selection.name.value].type;
```

reads `.type` off `undefined`. This is common — Apollo Client auto-injects `__typename`, and many fragments select it explicitly.

## Fix

Resolve the meta-field via graphql-js's exported `TypeNameMetaFieldDef`:

```ts
const field =
  selection.name.value === TypeNameMetaFieldDef.name
    ? TypeNameMetaFieldDef
    : (parent as GraphQLObjectType).getFields()[selection.name.value];
const type = field.type;
```

`TypeNameMetaFieldDef.type` is `String!`.

## Tests

Added an operations test that selects `__typename` alongside regular fields.

> Note: the new test uses `toMatchSnapshot()`, so its snapshot needs to be generated with `jest -u` (I couldn't run the test suite in my environment). Happy to push the generated snapshot if you'd prefer it committed here.

Closes #86
